### PR TITLE
Add new clients

### DIFF
--- a/pytest/fast_api/test_routes.py
+++ b/pytest/fast_api/test_routes.py
@@ -1,10 +1,12 @@
+import json
+
 import pytest
 
 from main import database
 
 
 @pytest.mark.asyncio
-async def test_request_example(fast_api_test_client):
+async def test_get_clients(fast_api_test_client):
     test_user_list = [
         {"name": "ANDRE JOSE", "active": "TRUE"},
         {"name": "RITA MARIA", "active": "TRUE"},
@@ -12,6 +14,25 @@ async def test_request_example(fast_api_test_client):
     query = "INSERT INTO clients (name, active) VALUES (:name, :active)"
     await database.connect()
     await database.execute_many(query=query, values=test_user_list)
+    response = fast_api_test_client.get("/clients")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"id": 1, "name": "ANDRE JOSE", "active": "TRUE"},
+        {"id": 2, "name": "RITA MARIA", "active": "TRUE"},
+    ]
+    await database.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_add_clients(fast_api_test_client):
+    test_user_list = [
+        {"name": "ANDRE JOSE"},
+        {"name": "RITA MARIA"},
+    ]
+    await database.connect()
+    for user in test_user_list:
+        fast_api_test_client.post("/add_client/", data=json.dumps(user))
+
     response = fast_api_test_client.get("/clients")
     assert response.status_code == 200
     assert response.json() == [


### PR DESCRIPTION
Introduce new add_clients POST endpoint which allows the user to add new clients to the DB.

Added tests which cover the change.